### PR TITLE
Close/Minimize/Maximize buttons are out of place on macOS Big Sur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@kylefoo/custom-electron-titlebar",
-  "version": "4.1.8",
+  "name": "@meetbutter/custom-electron-title-bar",
+  "version": "4.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetbutter/custom-electron-title-bar",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2477,11 +2477,6 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
-    },
-    "@treverix/remote": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@treverix/remote/-/remote-0.1.1.tgz",
-      "integrity": "sha512-StCJIIf0DuT7VpR/CO0ErVr7NLlqnoLBsbUfQ+Ouqaas8eGxReklEy/fW+gY0lYDlMXYQ6cc3qvOoOPtxoLukQ=="
     },
     "@types/babel__core": {
       "version": "7.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@treverix/custom-electron-titlebar",
-  "version": "4.1.6",
+  "name": "@kylefoo/custom-electron-titlebar",
+  "version": "4.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2477,6 +2477,11 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@treverix/remote": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@treverix/remote/-/remote-0.1.1.tgz",
+      "integrity": "sha512-StCJIIf0DuT7VpR/CO0ErVr7NLlqnoLBsbUfQ+Ouqaas8eGxReklEy/fW+gY0lYDlMXYQ6cc3qvOoOPtxoLukQ=="
     },
     "@types/babel__core": {
       "version": "7.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetbutter/custom-electron-title-bar",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Custom Electron Titlebar is a library for electron 10+ that allows you to configure a fully customizable title bar.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@meetbutter/custom-electron-titlebar",
+  "name": "@meetbutter/custom-electron-title-bar",
   "version": "4.1.8",
   "description": "Custom Electron Titlebar is a library for electron 10+ that allows you to configure a fully customizable title bar.",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@treverix/custom-electron-titlebar",
-  "version": "4.1.7",
+  "name": "@meetbutter/custom-electron-titlebar",
+  "version": "4.1.8",
   "description": "Custom Electron Titlebar is a library for electron 10+ that allows you to configure a fully customizable title bar.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,12 +15,13 @@
   },
   "author": "Andreas Dolk <treverixdev@gmail.com>",
   "contributors": [
-    "Alex Torres <alextorressk@gmail.com>"
+    "Alex Torres <alextorressk@gmail.com>",
+    "Kyle Foo <kylefoo@butter.us>"
   ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Treverix/custom-electron-titlebar.git"
+    "url": "git+https://github.com/kylefoo/custom-electron-titlebar.git"
   },
   "keywords": [
     "typescript",
@@ -53,13 +54,13 @@
     "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-import-require-as-string": "^1.0.2",
     "babel-plugin-module-resolver": "^4.0.0",
-    "electron": "^11.0.3",
-    "typescript": "^4.1.2",
     "babel-plugin-rewire": "^1.2.0",
+    "electron": "^11.0.3",
     "jest": "^26.6.3",
     "jest-electron": "^0.1.11",
     "ncp": "^2.0.0",
     "rewire": "^5.0.0",
-    "ts-jest": "^26.4.4"
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetbutter/custom-electron-title-bar",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "Custom Electron Titlebar is a library for electron 10+ that allows you to configure a fully customizable title bar.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kylefoo/custom-electron-titlebar.git"
+    "url": "git+https://github.com/MeetButter/custom-electron-titlebar.git"
   },
   "keywords": [
     "typescript",
@@ -32,9 +32,9 @@
     "linux"
   ],
   "bugs": {
-    "url": "https://github.com/Treverix/custom-electron-titlebar/issues"
+    "url": "https://github.com/MeetButter/custom-electron-titlebar/issues"
   },
-  "homepage": "https://github.com/Treverix/custom-electron-titlebar#readme",
+  "homepage": "https://github.com/MeetButter/custom-electron-titlebar#readme",
   "directories": {
     "example": "example",
     "lib": "lib"

--- a/src/menuitem.ts
+++ b/src/menuitem.ts
@@ -20,7 +20,7 @@ import {
     EventHelper,
     EventLike
 } from "vs/base/browser/dom";
-import {BrowserWindow, remote, Accelerator, NativeImage, MenuItem} from "electron";
+import {BrowserWindow, Accelerator, NativeImage, MenuItem} from "electron";
 import {MENU_MNEMONIC_REGEX, cleanMnemonic, MENU_ESCAPED_MNEMONIC_REGEX} from "./mnemonic";
 import {KeyCode, KeyCodeUtils} from "vs/base/common/keyCodes";
 import {Disposable} from "vs/base/common/lifecycle";
@@ -28,6 +28,7 @@ import {isMacintosh} from "vs/base/common/platform";
 import {IMenuItem, IMenuStyle, IMenuOptions} from './api'
 import * as strings from 'vs/base/common/strings';
 import {EventType as TouchEventType} from 'vs/base/browser/touch';
+const remote = require("@electron/remote");
 
 let menuItemId = 0;
 

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -37,7 +37,7 @@ const ACTIVE_FOREGROUND = Color.fromHex('#FFFFFF');
 
 const IS_MAC_BIGSUR_OR_LATER = isMacintosh && parseInt(process.getSystemVersion().split(".")[0]) >= 11;
 const BOTTOM_TITLEBAR_HEIGHT = '60px';
-const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '28px': '22px';
+const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '30px': '22px';
 const TOP_TITLEBAR_HEIGHT_WIN = '30px';
 
 const TitlebarEventType = {

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -38,7 +38,6 @@ const ACTIVE_FOREGROUND = Color.fromHex('#FFFFFF');
 const IS_MAC_BIGSUR_OR_LATER = isMacintosh && parseInt(process.getSystemVersion().split(".")[0]) >= 11;
 const BOTTOM_TITLEBAR_HEIGHT = '60px';
 const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '28px': '22px';
-const TOP_TITLEBAR_HEIGHT_MAC = '22px';
 const TOP_TITLEBAR_HEIGHT_WIN = '30px';
 
 const TitlebarEventType = {

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -35,7 +35,9 @@ const ACTIVE_FOREGROUND_DARK = Color.fromHex('#333333');
 const INACTIVE_FOREGROUND = Color.fromHex('#EEEEEE');
 const ACTIVE_FOREGROUND = Color.fromHex('#FFFFFF');
 
+const IS_MAC_BIGSUR_OR_LATER = isMacintosh && parseInt(process.getSystemVersion().split(".")[0]) >= 11;
 const BOTTOM_TITLEBAR_HEIGHT = '60px';
+const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '28px': '22px';
 const TOP_TITLEBAR_HEIGHT_MAC = '22px';
 const TOP_TITLEBAR_HEIGHT_WIN = '30px';
 
@@ -199,6 +201,11 @@ export class Titlebar extends Themebar {
         if (!isMacintosh) {
             this.title.style.cursor = 'default';
         }
+
+        if (IS_MAC_BIGSUR_OR_LATER) {
+			this.title.style.fontWeight = "600";
+			this.title.style.fontSize = "13px";
+		}
 
         this.updateTitle();
         this.setHorizontalAlignment(this._options.titleHorizontalAlignment);

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -202,9 +202,9 @@ export class Titlebar extends Themebar {
         }
 
         if (IS_MAC_BIGSUR_OR_LATER) {
-			this.title.style.fontWeight = "600";
-			this.title.style.fontSize = "13px";
-		}
+            this.title.style.fontWeight = "600";
+            this.title.style.fontSize = "13px";
+        }
 
         this.updateTitle();
         this.setHorizontalAlignment(this._options.titleHorizontalAlignment);


### PR DESCRIPTION
Im on electron 14.0.0 but facing issue with Close/Minimize/Maximize buttons out of the place on macOS Big Sur

Refers to same fixes done here:
https://github.com/AlexTorresSk/custom-electron-titlebar/pull/114