### PR TITLE
Task/Traffic-light-buttons-are-out-of-place-on-macOs-big-sur

### DIFF
--- a/src/menuitem.ts
+++ b/src/menuitem.ts
@@ -20,7 +20,7 @@ import {
     EventHelper,
     EventLike
 } from "vs/base/browser/dom";
-import {BrowserWindow, remote, Accelerator, NativeImage, MenuItem} from "electron";
+import {BrowserWindow, Accelerator, NativeImage, MenuItem} from "electron";
 import {MENU_MNEMONIC_REGEX, cleanMnemonic, MENU_ESCAPED_MNEMONIC_REGEX} from "./mnemonic";
 import {KeyCode, KeyCodeUtils} from "vs/base/common/keyCodes";
 import {Disposable} from "vs/base/common/lifecycle";
@@ -28,6 +28,7 @@ import {isMacintosh} from "vs/base/common/platform";
 import {IMenuItem, IMenuStyle, IMenuOptions} from './api'
 import * as strings from 'vs/base/common/strings';
 import {EventType as TouchEventType} from 'vs/base/browser/touch';
+const remote = require("@electron/remote");
 
 let menuItemId = 0;
 

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -38,7 +38,6 @@ const ACTIVE_FOREGROUND = Color.fromHex('#FFFFFF');
 const IS_MAC_BIGSUR_OR_LATER = isMacintosh && parseInt(process.getSystemVersion().split(".")[0]) >= 11;
 const BOTTOM_TITLEBAR_HEIGHT = '60px';
 const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '28px': '22px';
-const TOP_TITLEBAR_HEIGHT_MAC = '22px';
 const TOP_TITLEBAR_HEIGHT_WIN = '30px';
 
 const TitlebarEventType = {

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -35,7 +35,9 @@ const ACTIVE_FOREGROUND_DARK = Color.fromHex('#333333');
 const INACTIVE_FOREGROUND = Color.fromHex('#EEEEEE');
 const ACTIVE_FOREGROUND = Color.fromHex('#FFFFFF');
 
+const IS_MAC_BIGSUR_OR_LATER = isMacintosh && parseInt(process.getSystemVersion().split(".")[0]) >= 11;
 const BOTTOM_TITLEBAR_HEIGHT = '60px';
+const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '28px': '22px';
 const TOP_TITLEBAR_HEIGHT_MAC = '22px';
 const TOP_TITLEBAR_HEIGHT_WIN = '30px';
 
@@ -199,6 +201,11 @@ export class Titlebar extends Themebar {
         if (!isMacintosh) {
             this.title.style.cursor = 'default';
         }
+
+        if (IS_MAC_BIGSUR_OR_LATER) {
+			this.title.style.fontWeight = "600";
+			this.title.style.fontSize = "13px";
+		}
 
         this.updateTitle();
         this.setHorizontalAlignment(this._options.titleHorizontalAlignment);

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -202,9 +202,9 @@ export class Titlebar extends Themebar {
         }
 
         if (IS_MAC_BIGSUR_OR_LATER) {
-			this.title.style.fontWeight = "600";
-			this.title.style.fontSize = "13px";
-		}
+            this.title.style.fontWeight = "600";
+            this.title.style.fontSize = "13px";
+        }
 
         this.updateTitle();
         this.setHorizontalAlignment(this._options.titleHorizontalAlignment);


### PR DESCRIPTION
On electron 14.0.0 but facing issue with Close/Minimize/Maximize buttons out of the place on macOS Big Sur

Refers to same fixes done here:
AlexTorresSk#114